### PR TITLE
feat: add @birrjs/sms-gate notification plugin

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@birrjs/chapa": "workspace:*",
     "@birrjs/core": "workspace:*",
+    "@birrjs/sms-gate": "workspace:*",
     "@types/pg": "^8.18.0",
     "drizzle-orm": "^0.45.1",
     "pg": "^8.20.0",

--- a/e2e/smoke/sms-gate-client.test.ts
+++ b/e2e/smoke/sms-gate-client.test.ts
@@ -136,6 +136,16 @@ describe("SmsGateClient", () => {
       expect(sends).toHaveLength(2);
     });
 
+    it("throws SmsGateAuthError on second 401 instead of infinite retry", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(401, {});
+      mockFetch(201, jwtResponse());
+      mockFetch(401, {});
+
+      const client = new SmsGateClient(config);
+      await expect(client.send("+251700000000", "retry")).rejects.toThrow(SmsGateAuthError);
+    });
+
     it("throws SmsGateValidationError on 400", async () => {
       mockFetch(201, jwtResponse());
       mockFetch(400, { message: "Invalid phone" });

--- a/e2e/smoke/sms-gate-client.test.ts
+++ b/e2e/smoke/sms-gate-client.test.ts
@@ -1,0 +1,189 @@
+import {
+  SmsGateClient,
+  SmsGateAuthError,
+  SmsGateDeviceError,
+  SmsGateQueueError,
+  SmsGateValidationError,
+  type SmsGateConfig,
+} from "@birrjs/sms-gate";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const config: SmsGateConfig = {
+  username: "testuser",
+  password: "testpass",
+  deviceId: "dev-123",
+  simNumber: 1,
+};
+
+function mockFetch(status: number, body: unknown) {
+  return vi.mocked(fetch).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({ "Content-Type": "application/json" }),
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function jwtResponse() {
+  return {
+    access_token: "jwt-token",
+    refresh_token: "refresh-token",
+    expires_at: new Date(Date.now() + 86400000).toISOString(),
+  };
+}
+
+beforeEach(() => {
+  vi.spyOn(globalThis, "fetch").mockReset();
+});
+
+describe("SmsGateClient", () => {
+  describe("auth", () => {
+    it("authenticates with Basic then uses Bearer JWT", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m1", state: "Pending", recipients: [] });
+
+      const client = new SmsGateClient(config);
+      await client.send("+251700000000", "Hello!");
+
+      const authCall = vi
+        .mocked(fetch)
+        .mock.calls.find(([u]) => (u as string).includes("/auth/token"));
+      expect((authCall![1] as RequestInit).headers).toMatchObject({
+        Authorization: `Basic ${btoa("testuser:testpass")}`,
+      });
+
+      const msgCall = vi
+        .mocked(fetch)
+        .mock.calls.find(([u]) => (u as string).includes("/messages"));
+      expect((msgCall![1] as RequestInit).headers).toMatchObject({
+        Authorization: "Bearer jwt-token",
+      });
+    });
+
+    it("throws SmsGateAuthError on 401", async () => {
+      mockFetch(401, { message: "Bad credentials" });
+
+      const client = new SmsGateClient(config);
+      await expect(client.send("+251700000000", "test")).rejects.toThrow(SmsGateAuthError);
+    });
+  });
+
+  describe("send()", () => {
+    it("sends textMessage with phone number", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m1", state: "Pending", recipients: [] });
+
+      const client = new SmsGateClient(config);
+      await client.send("+251700000000", "Hello world");
+
+      const body = sentBody("/messages");
+      expect(body).toMatchObject({
+        textMessage: { text: "Hello world" },
+        phoneNumbers: ["+251700000000"],
+      });
+    });
+
+    it("includes deviceId and simNumber when configured", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m1", state: "Pending", recipients: [] });
+
+      const client = new SmsGateClient(config);
+      await client.send("+251700000000", "test");
+
+      const body = sentBody("/messages");
+      expect(body.deviceId).toBe("dev-123");
+      expect(body.simNumber).toBe(1);
+    });
+
+    it("omits optional fields when not configured", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m1", state: "Pending", recipients: [] });
+
+      const client = new SmsGateClient({ username: "u", password: "p" });
+      await client.send("+251700000000", "test");
+
+      const body = sentBody("/messages");
+      expect(body.deviceId).toBeUndefined();
+      expect(body.simNumber).toBeUndefined();
+    });
+
+    it("uses custom baseUrl", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m1", state: "Pending", recipients: [] });
+
+      const client = new SmsGateClient({ ...config, baseUrl: "http://localhost:8080" });
+      await client.send("+251700000000", "test");
+
+      const urls = vi.mocked(fetch).mock.calls.map(([u]) => u as string);
+      expect(urls.some((u) => u.startsWith("http://localhost:8080"))).toBe(true);
+    });
+  });
+
+  describe("error handling", () => {
+    it("retries once on 401", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(401, {});
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m2", state: "Pending", recipients: [] });
+
+      const client = new SmsGateClient(config);
+      await client.send("+251700000000", "retry");
+
+      const sends = vi
+        .mocked(fetch)
+        .mock.calls.filter(([u]) => (u as string).includes("/messages"));
+      expect(sends).toHaveLength(2);
+    });
+
+    it("throws SmsGateValidationError on 400", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(400, { message: "Invalid phone" });
+
+      const client = new SmsGateClient(config);
+      await expect(client.send("bad", "test")).rejects.toThrow(SmsGateValidationError);
+    });
+
+    it("throws SmsGateAuthError on 403", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(403, { message: "Scope required" });
+
+      const client = new SmsGateClient(config);
+      await expect(client.send("+251700000000", "test")).rejects.toThrow(SmsGateAuthError);
+    });
+
+    it("throws SmsGateQueueError on 503 with QueueLimitExceeded", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(503, { error: "QueueLimitExceeded", message: "too many pending" });
+
+      const client = new SmsGateClient(config);
+      await expect(client.send("+251700000000", "test")).rejects.toThrow(SmsGateQueueError);
+    });
+
+    it("throws SmsGateDeviceError on recipient failure", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, {
+        id: "m3",
+        recipients: [
+          { phoneNumber: "+251700000000", state: "Failed", error: "SEND_SMS permission" },
+        ],
+      });
+
+      const client = new SmsGateClient(config);
+      await expect(client.send("+251700000000", "test")).rejects.toThrow(SmsGateDeviceError);
+    });
+
+    it("succeeds without error on Sent", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m4", recipients: [{ phoneNumber: "+251700000000", state: "Sent" }] });
+
+      const client = new SmsGateClient(config);
+      await expect(client.send("+251700000000", "test")).resolves.not.toThrow();
+    });
+  });
+});
+
+function sentBody(pathPart: string): Record<string, unknown> {
+  const call = vi.mocked(fetch).mock.calls.find(([u]) => (u as string).includes(pathPart));
+  return JSON.parse((call![1] as RequestInit).body as string);
+}

--- a/e2e/smoke/sms-gate-plugin.test.ts
+++ b/e2e/smoke/sms-gate-plugin.test.ts
@@ -1,0 +1,302 @@
+import type { BirrJSContext } from "@birrjs/core";
+import { smsGate, type SmsGateConfig } from "@birrjs/sms-gate";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const config: SmsGateConfig = {
+  username: "testuser",
+  password: "testpass",
+  deviceId: "dev-123",
+};
+
+function mockFetch(status: number, body: unknown) {
+  return vi.mocked(fetch).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({ "Content-Type": "application/json" }),
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function jwtResponse() {
+  return {
+    access_token: "jwt",
+    refresh_token: "refresh",
+    expires_at: new Date(Date.now() + 86400000).toISOString(),
+  };
+}
+
+function mockContext(overrides?: Partial<BirrJSContext>): BirrJSContext {
+  return {
+    options: {} as any,
+    queries: { getCustomer: vi.fn(), getSubscription: vi.fn() },
+    database: {} as any,
+    provider: {} as any,
+    runtime: {} as any,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      fatal: vi.fn(),
+      child: vi.fn(),
+    } as any,
+    destroy: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.spyOn(globalThis, "fetch").mockReset();
+});
+
+describe("smsGate() plugin integration", () => {
+  describe("subscription.activated", () => {
+    it("sends payment received SMS to customer phone", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m1", state: "Pending", recipients: [] });
+
+      const plugin = smsGate(config);
+      const ctx = mockContext({
+        queries: {
+          getCustomer: vi.fn().mockResolvedValue({ id: "c1", phone: "+251900000001" }),
+          getSubscription: vi.fn(),
+        },
+      });
+
+      await plugin.onEvent!["subscription.activated"]!(
+        {
+          customerId: "c1",
+          planName: "Pro",
+          planId: "pro",
+          subscriptionId: "s1",
+          customerEmail: "a@b.com",
+          startedAt: new Date(),
+          expiresAt: null,
+        },
+        ctx,
+      );
+
+      const body = sentBody("/messages");
+      expect(body.phoneNumbers).toEqual(["+251900000001"]);
+      expect(body.textMessage.text).toMatch(/payment.*received/i);
+    });
+
+    it("skips if customer has no phone", async () => {
+      const plugin = smsGate(config);
+      const ctx = mockContext({
+        queries: {
+          getCustomer: vi.fn().mockResolvedValue({ id: "c1", phone: null }),
+          getSubscription: vi.fn(),
+        },
+      });
+
+      await plugin.onEvent!["subscription.activated"]!(
+        {
+          customerId: "c1",
+          planName: "Pro",
+          planId: "pro",
+          subscriptionId: "s1",
+          customerEmail: "a@b.com",
+          startedAt: new Date(),
+          expiresAt: null,
+        },
+        ctx,
+      );
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("skips if customer not found", async () => {
+      const plugin = smsGate(config);
+      const ctx = mockContext({
+        queries: { getCustomer: vi.fn().mockResolvedValue(null), getSubscription: vi.fn() },
+      });
+
+      await plugin.onEvent!["subscription.activated"]!(
+        {
+          customerId: "missing",
+          planName: "Pro",
+          planId: "pro",
+          subscriptionId: "s1",
+          customerEmail: "a@b.com",
+          startedAt: new Date(),
+          expiresAt: null,
+        },
+        ctx,
+      );
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("subscription.cancelled", () => {
+    it("sends payment failed SMS", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m1", state: "Pending", recipients: [] });
+
+      const plugin = smsGate(config);
+      const ctx = mockContext({
+        queries: {
+          getCustomer: vi.fn().mockResolvedValue({ id: "c1", phone: "+251900000001" }),
+          getSubscription: vi.fn(),
+        },
+      });
+
+      await plugin.onEvent!["subscription.cancelled"]!(
+        {
+          customerId: "c1",
+          planName: "Basic",
+          planId: "basic",
+          subscriptionId: "s1",
+          customerEmail: null,
+          canceledAt: new Date(),
+          endedAt: null,
+        },
+        ctx,
+      );
+
+      expect(sentBody("/messages").textMessage.text).toContain("payment failed");
+    });
+  });
+
+  describe("subscription.expired", () => {
+    it("sends expired SMS", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m1", state: "Pending", recipients: [] });
+
+      const plugin = smsGate(config);
+      const ctx = mockContext({
+        queries: {
+          getCustomer: vi.fn().mockResolvedValue({ id: "c1", phone: "+251900000001" }),
+          getSubscription: vi.fn(),
+        },
+      });
+
+      await plugin.onEvent!["subscription.expired"]!(
+        {
+          customerId: "c1",
+          planName: "Pro",
+          planId: "pro",
+          subscriptionId: "s1",
+          customerEmail: null,
+          expiredAt: new Date(),
+        },
+        ctx,
+      );
+
+      expect(sentBody("/messages").textMessage.text).toContain("expired");
+    });
+  });
+
+  describe("subscription.reminder", () => {
+    it("uses customerPhone from payload, not getCustomer", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m1", state: "Pending", recipients: [] });
+
+      const plugin = smsGate(config);
+      const getCustomer = vi.fn();
+      const ctx = mockContext({ queries: { getCustomer, getSubscription: vi.fn() } });
+
+      await plugin.onEvent!["subscription.reminder"]!(
+        {
+          customerId: "c1",
+          planName: "Pro",
+          planId: "pro",
+          subscriptionId: "s1",
+          customerEmail: null,
+          customerPhone: "+251900000001",
+          expiresAt: new Date(),
+          daysUntilExpiry: 3,
+        },
+        ctx,
+      );
+
+      expect(getCustomer).not.toHaveBeenCalled();
+      const body = sentBody("/messages");
+      expect(body.phoneNumbers).toEqual(["+251900000001"]);
+      expect(body.textMessage.text).toContain("expires in 3 days");
+    });
+
+    it("skips if payload has no customerPhone", async () => {
+      const plugin = smsGate(config);
+      const ctx = mockContext();
+
+      await plugin.onEvent!["subscription.reminder"]!(
+        {
+          customerId: "c1",
+          planName: "Pro",
+          planId: "pro",
+          subscriptionId: "s1",
+          customerEmail: null,
+          customerPhone: null,
+          expiresAt: new Date(),
+          daysUntilExpiry: 3,
+        },
+        ctx,
+      );
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("custom message templates", () => {
+    it("uses custom messages from config", async () => {
+      mockFetch(201, jwtResponse());
+      mockFetch(201, { id: "m1", state: "Pending", recipients: [] });
+
+      const custom: SmsGateConfig = {
+        ...config,
+        messages: {
+          paymentReceived: "Thanks {planName} subscriber!",
+          paymentFailed: "Oops {planName}",
+        },
+      };
+
+      const plugin = smsGate(custom);
+      const ctx = mockContext({
+        queries: {
+          getCustomer: vi.fn().mockResolvedValue({ id: "c1", phone: "+251900000001" }),
+          getSubscription: vi.fn(),
+        },
+      });
+
+      await plugin.onEvent!["subscription.activated"]!(
+        {
+          customerId: "c1",
+          planName: "Gold",
+          planId: "gold",
+          subscriptionId: "s1",
+          customerEmail: null,
+          startedAt: new Date(),
+          expiresAt: null,
+        },
+        ctx,
+      );
+
+      expect(sentBody("/messages").textMessage.text).toBe("Thanks Gold subscriber!");
+    });
+  });
+
+  describe("plugin shape", () => {
+    it("has id sms-gate", () => {
+      expect(smsGate(config).id).toBe("sms-gate");
+    });
+
+    it("has no lifecycle hooks (only onEvent)", () => {
+      const plugin = smsGate(config);
+      expect(plugin.onBeforeSubscribe).toBeUndefined();
+      expect(plugin.onCheckoutReady).toBeUndefined();
+      expect(plugin.onPaymentReady).toBeUndefined();
+      expect(plugin.endpoints).toBeUndefined();
+    });
+  });
+});
+
+function sentBody(
+  pathPart: string,
+): { textMessage: { text: string }; phoneNumbers: string[] } & Record<string, unknown> {
+  const call = vi.mocked(fetch).mock.calls.find(([u]) => (u as string).includes(pathPart));
+  if (!call) throw new Error(`No fetch call to ${pathPart}`);
+  return JSON.parse((call[1] as RequestInit).body as string);
+}

--- a/e2e/smoke/sms-gate.test.ts
+++ b/e2e/smoke/sms-gate.test.ts
@@ -1,0 +1,32 @@
+import { SmsGateClient, SmsGateError } from "@birrjs/sms-gate";
+import { describe, it, expect, beforeAll } from "vitest";
+
+const hasCredentials = !!(process.env.SMS_GATE_USERNAME && process.env.SMS_GATE_PASSWORD);
+const testNumber = process.env.SMS_GATE_TO ?? "+251704207309";
+
+describe.skipIf(!hasCredentials)("SMS-Gate send", () => {
+  let client: SmsGateClient;
+
+  beforeAll(() => {
+    client = new SmsGateClient({
+      username: process.env.SMS_GATE_USERNAME!,
+      password: process.env.SMS_GATE_PASSWORD!,
+      deviceId: process.env.SMS_GATE_DEVICE_ID || undefined,
+    });
+  });
+
+  it("sends a real SMS and returns a message ID", async () => {
+    const result = await client.send(testNumber, "Smoke test from birrjs sms-gate plugin");
+    expect(result.id).toBeTruthy();
+    expect(result.state).toBe("Pending");
+    expect(result.recipients[0]?.state).toBe("Pending");
+  }, 30_000);
+
+  it("throws SmsGateError with wrong credentials", async () => {
+    const bad = new SmsGateClient({
+      username: "invalid",
+      password: "invalid",
+    });
+    await expect(bad.send(testNumber, "should fail")).rejects.toThrow(SmsGateError);
+  }, 15_000);
+});

--- a/landing/content/docs/plugins/notification/meta.json
+++ b/landing/content/docs/plugins/notification/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Notification Providers",
-  "pages": ["afromessage", "resend"]
+  "pages": ["afromessage", "sms-gate", "resend"]
 }

--- a/landing/content/docs/plugins/notification/sms-gate.mdx
+++ b/landing/content/docs/plugins/notification/sms-gate.mdx
@@ -1,0 +1,147 @@
+---
+title: SMS-Gate
+description: Send SMS notifications on subscription events via SMS-Gate.
+---
+
+[SMS-Gate](https://sms-gate.app) is an open-source Android app that turns any phone with a SIM card into an SMS gateway. You install it on a device, connect it to their free cloud server (or self-host), and hit a REST API to send SMS through that phone's cellular connection. No carrier API subscriptions, no regulatory paperwork — just an Android phone and a SIM.
+
+The `@birrjs/sms-gate` plugin sends SMS messages to customers when subscription events occur — payment received, payment failed, subscription expired, or expiring soon.
+
+## Installation
+
+```bash
+pnpm add @birrjs/sms-gate
+```
+
+## Configuration
+
+```ts
+import { smsGate } from "@birrjs/sms-gate";
+import { createBirr } from "@birrjs/core";
+
+createBirr({
+  // ... other options
+  plugins: [
+    smsGate({
+      username: process.env.SMS_GATE_USERNAME!,
+      password: process.env.SMS_GATE_PASSWORD!,
+      deviceId: process.env.SMS_GATE_DEVICE_ID,       // optional
+      simNumber: 1,                                     // optional
+    }),
+  ],
+});
+```
+
+### Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SMS_GATE_USERNAME` | Yes | Username from sms-gate.app credentials |
+| `SMS_GATE_PASSWORD` | Yes | Password from sms-gate.app credentials |
+| `SMS_GATE_DEVICE_ID` | No | Target a specific device (omit to let the server pick one) |
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `username` | `string` | — | SMS-Gate account username |
+| `password` | `string` | — | SMS-Gate account password |
+| `baseUrl` | `string` | `"https://api.sms-gate.app"` | API base URL — change for self-hosted or private server |
+| `deviceId` | `string` | — | Target a specific device |
+| `simNumber` | `number` | — | SIM card slot (1–3) |
+| `messages` | `object` | (defaults below) | Override message templates per event |
+
+## How it works
+
+The plugin authenticates using your username and password, then manages JWT tokens automatically — refreshing them before expiry and re-authenticating if the refresh token expires. It listens to subscription lifecycle events and sends an SMS to the customer's phone number.
+
+| Event | Default message |
+|-------|----------------|
+| `subscription.activated` | "Your payment has been received. Thank you!" |
+| `subscription.cancelled` | "Your payment failed. Please update your payment method." |
+| `subscription.expired` | "Your subscription has expired. Renew now to continue access." |
+| `subscription.reminder` | "Reminder: your subscription expires in \{daysUntil\} days. Renew now!" |
+
+### Phone number
+
+The phone number is read from the `birrjs_customer.phone` column — except for `subscription.reminder` events, where the number comes directly from the event payload. Set it on your customer record:
+
+```ts
+import { db } from "./db";
+import { birrjsCustomer } from "./schema";
+
+export async function setPhone(customerId: string, phone: string) {
+  await db.insert(birrjsCustomer)
+    .values({ id: customerId, phone })
+    .onConflictDoUpdate({ target: birrjsCustomer.id, set: { phone } });
+}
+```
+
+If the customer has no phone number when an event fires, the SMS is silently skipped.
+
+### Authentication
+
+SMS-Gate uses JWT tokens for API access. The plugin handles the full token lifecycle internally:
+
+1. On first send, it authenticates with your username and password to obtain a JWT token pair (access token + refresh token)
+2. Before each send, it checks if the access token is close to expiry and refreshes it automatically
+3. If the refresh token expires (~30 days), it re-authenticates from scratch
+
+## Custom messages
+
+Override the default messages with your own templates:
+
+```ts
+smsGate({
+  messages: {
+    paymentReceived: "Payment confirmed! Your {planName} plan is active.",
+    paymentFailed: "Payment failed for {planName}. Please update your payment method.",
+    subscriptionExpired: "Your {planName} subscription has ended. Renew now.",
+    subscriptionReminder: "Hi! Your {planName} expires in {daysUntil} days.",
+  },
+})
+```
+
+Template variables are enclosed in `{curly braces}`:
+
+| Variable | Available in |
+|----------|-------------|
+| `{planName}` | All events |
+| `{daysUntil}` | `subscription.reminder` only |
+
+## Multi-device and multi-SIM
+
+If you have multiple Android devices running SMS-Gate or a device with multiple SIM cards:
+
+- Use `deviceId` to route messages to a specific device — useful for separating personal and business lines
+- Use `simNumber` to pick which SIM slot to send from (1, 2, or 3) — useful when carriers have different SMS rates or reliability
+- If neither is specified, the server picks an available device and the device uses its default SIM
+
+You can list your devices and their IDs via the API:
+
+```bash
+curl -u "username:password" https://api.sms-gate.app/3rdparty/v1/devices
+```
+
+## Self-hosted server
+
+If you're running a [private server](https://docs.sms-gate.app/getting-started/private-server/), set `baseUrl` to your server's address:
+
+```ts
+smsGate({
+  baseUrl: "https://sms-gate.yourcompany.com",
+  username: process.env.SMS_GATE_USERNAME!,
+  password: process.env.SMS_GATE_PASSWORD!,
+})
+```
+
+## Error handling
+
+The plugin throws typed errors that you can catch and handle programmatically:
+
+| Error class | When it occurs |
+|-------------|----------------|
+| `SmsGateAuthError` | Invalid credentials, expired token, missing scope |
+| `SmsGateValidationError` | Bad request (invalid phone number, missing fields) |
+| `SmsGateQueueError` | Device queue full (too many pending messages) |
+| `SmsGateDeviceError` | Device-side failure (SMS permission, no SIM, modem error) |

--- a/landing/src/components/docs/docs-icons.tsx
+++ b/landing/src/components/docs/docs-icons.tsx
@@ -50,6 +50,7 @@ const pageIcons = {
   providers: <CreditCard className="docs-category-icon size-3! shrink-0" />,
   plugins: <Blocks className="docs-category-icon size-3! shrink-0" />,
   afromessage: <MessageSquare className="docs-category-icon size-3! shrink-0" />,
+  "sms gate": <MessageSquare className="docs-category-icon size-3! shrink-0" />,
   "your first plugin": <Code className="docs-category-icon size-3! shrink-0" />,
   fayda: <Landmark className="docs-category-icon size-3! shrink-0" />,
   coupon: <Ticket className="docs-category-icon size-3! shrink-0" />,

--- a/packages/sms-gate/README.md
+++ b/packages/sms-gate/README.md
@@ -1,0 +1,46 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/Samuel-Fikre/birrjs/main/assets/birrjs-logo.svg" width="80" alt="BirrJS Logo"/>
+
+  <h3 align="center">@birrjs/sms-gate</h3>
+
+  <p align="center">
+    SMS-Gate plugin for BirrJS — send subscription notifications via sms-gate.app
+  </p>
+
+  <p align="center">
+    <a href="https://www.npmjs.com/package/@birrjs/sms-gate"><img src="https://img.shields.io/npm/v/@birrjs/sms-gate.svg?style=flat&colorA=000000&colorB=000000" alt="npm version"/></a>
+    <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-black.svg?style=flat&colorA=000000&colorB=000000" alt="MIT license"/></a>
+  </p>
+</div>
+
+## About
+
+SMS-Gate plugin for BirrJS. Sends subscription reminders and notifications via SMS through the [SMS-Gate](https://sms-gate.app) API using an Android device connected to the service.
+
+## Installation
+
+```bash
+npm install @birrjs/sms-gate
+# or
+pnpm add @birrjs/sms-gate
+```
+
+## Usage
+
+```ts
+import { smsGate } from "@birrjs/sms-gate";
+
+const birr = createBirr({
+  plugins: [
+    smsGate({
+      username: process.env.SMS_GATE_USERNAME!,
+      password: process.env.SMS_GATE_PASSWORD!,
+    }),
+  ],
+  // ...
+});
+```
+
+## License
+
+MIT

--- a/packages/sms-gate/package.json
+++ b/packages/sms-gate/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@birrjs/sms-gate",
+  "version": "0.1.0",
+  "description": "SMS-Gate plugin for BirrJS — send subscription notifications via sms-gate.app",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "scripts": {
+    "build": "tsdown --config tsdown.config.ts",
+    "typecheck": "tsc --build",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@birrjs/core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsdown": "^0.21.1",
+    "typescript": "5.9.2",
+    "vitest": "^4.1.6"
+  }
+}

--- a/packages/sms-gate/src/client.ts
+++ b/packages/sms-gate/src/client.ts
@@ -77,7 +77,7 @@ export class SmsGateClient {
     this.baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
   }
 
-  async send(to: string, message: string): Promise<SendResponse> {
+  async send(to: string, message: string, retried?: boolean): Promise<SendResponse> {
     await this.ensureToken();
 
     const body: Record<string, unknown> = {
@@ -97,9 +97,13 @@ export class SmsGateClient {
     });
 
     if (response.status === 401) {
+      if (retried) {
+        this.accessToken = null;
+        throw new SmsGateAuthError("Authentication failed after retry", 401);
+      }
       this.accessToken = null;
       await this.ensureToken();
-      return this.send(to, message);
+      return this.send(to, message, true);
     }
 
     if (!response.ok) {

--- a/packages/sms-gate/src/client.ts
+++ b/packages/sms-gate/src/client.ts
@@ -1,0 +1,217 @@
+import type { SmsGateConfig } from "./types";
+
+const DEFAULT_BASE_URL = "https://api.sms-gate.app";
+
+interface TokenResponse {
+  id: string;
+  access_token: string;
+  refresh_token: string;
+  expires_at: string;
+}
+
+interface SendResponse {
+  id: string;
+  deviceId: string;
+  state: string;
+  recipients: Array<{
+    phoneNumber: string;
+    state: string;
+    error?: string;
+  }>;
+}
+
+export class SmsGateError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly status?: number,
+    public readonly details?: string,
+  ) {
+    super(message);
+    this.name = "SmsGateError";
+  }
+}
+
+export class SmsGateAuthError extends SmsGateError {
+  constructor(message: string, status?: number) {
+    super(message, "AUTH_ERROR", status);
+    this.name = "SmsGateAuthError";
+  }
+}
+
+export class SmsGateDeviceError extends SmsGateError {
+  constructor(
+    message: string,
+    public readonly phoneNumber: string,
+    public readonly deviceError: string,
+    status?: number,
+  ) {
+    super(message, "DEVICE_ERROR", status, deviceError);
+    this.name = "SmsGateDeviceError";
+  }
+}
+
+export class SmsGateQueueError extends SmsGateError {
+  constructor(message: string) {
+    super(message, "QUEUE_LIMIT_EXCEEDED", 503);
+    this.name = "SmsGateQueueError";
+  }
+}
+
+export class SmsGateValidationError extends SmsGateError {
+  constructor(message: string) {
+    super(message, "VALIDATION_ERROR", 400);
+    this.name = "SmsGateValidationError";
+  }
+}
+
+export class SmsGateClient {
+  private config: SmsGateConfig;
+  private baseUrl: string;
+  private accessToken: string | null = null;
+  private refreshToken: string | null = null;
+  private tokenExpiresAt: Date | null = null;
+
+  constructor(config: SmsGateConfig) {
+    this.config = config;
+    this.baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+  }
+
+  async send(to: string, message: string): Promise<SendResponse> {
+    await this.ensureToken();
+
+    const body: Record<string, unknown> = {
+      textMessage: { text: message },
+      phoneNumbers: [to],
+    };
+    if (this.config.deviceId) body.deviceId = this.config.deviceId;
+    if (this.config.simNumber) body.simNumber = this.config.simNumber;
+
+    const response = await fetch(`${this.baseUrl}/3rdparty/v1/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (response.status === 401) {
+      this.accessToken = null;
+      await this.ensureToken();
+      return this.send(to, message);
+    }
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "Unknown error");
+      throw parseError(response.status, text);
+    }
+
+    const data = (await response.json()) as SendResponse;
+
+    for (const recipient of data.recipients) {
+      if (recipient.state === "Failed" && recipient.error) {
+        throw new SmsGateDeviceError(
+          `SMS to ${recipient.phoneNumber} failed: ${recipient.error}`,
+          recipient.phoneNumber,
+          recipient.error,
+        );
+      }
+    }
+
+    return data;
+  }
+
+  private async ensureToken(): Promise<void> {
+    if (this.accessToken && this.tokenExpiresAt) {
+      const fiveMinutesFromNow = new Date(Date.now() + 5 * 60 * 1000);
+      if (this.tokenExpiresAt > fiveMinutesFromNow) return;
+    }
+
+    if (this.refreshToken) {
+      try {
+        await this.refresh();
+        return;
+      } catch {
+        this.refreshToken = null;
+      }
+    }
+
+    await this.authenticate();
+  }
+
+  private async authenticate(): Promise<void> {
+    const credentials = btoa(`${this.config.username}:${this.config.password}`);
+    const response = await fetch(`${this.baseUrl}/3rdparty/v1/auth/token`, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        ttl: 86400,
+        scopes: ["messages:send"],
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "Unknown error");
+      if (response.status === 401) {
+        throw new SmsGateAuthError("Invalid SMS-Gate credentials", 401);
+      }
+      throw new SmsGateAuthError(
+        `Authentication failed (${response.status}): ${text}`,
+        response.status,
+      );
+    }
+
+    const data = (await response.json()) as TokenResponse;
+    this.accessToken = data.access_token;
+    this.refreshToken = data.refresh_token;
+    this.tokenExpiresAt = new Date(data.expires_at);
+  }
+
+  private async refresh(): Promise<void> {
+    const response = await fetch(`${this.baseUrl}/3rdparty/v1/auth/token/refresh`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.refreshToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) throw new SmsGateAuthError("Token refresh failed", response.status);
+
+    const data = (await response.json()) as TokenResponse;
+    this.accessToken = data.access_token;
+    this.refreshToken = data.refresh_token;
+    this.tokenExpiresAt = new Date(data.expires_at);
+  }
+}
+
+function parseError(status: number, body: string): SmsGateError {
+  let parsed: { error?: string; message?: string } = {};
+  try {
+    parsed = JSON.parse(body);
+  } catch {}
+
+  if (parsed.error === "QueueLimitExceeded") {
+    return new SmsGateQueueError(parsed.message ?? "Device queue limit exceeded");
+  }
+
+  switch (status) {
+    case 400:
+      return new SmsGateValidationError(parsed.message ?? "Invalid request");
+    case 401:
+      return new SmsGateAuthError(parsed.message ?? "Unauthorized", 401);
+    case 403:
+      return new SmsGateAuthError(
+        parsed.message ?? "Scope required - token lacks messages:send scope",
+        403,
+      );
+    case 503:
+      return new SmsGateQueueError(parsed.message ?? "Service unavailable");
+    default:
+      return new SmsGateError(parsed.message ?? `API error (${status})`, "API_ERROR", status, body);
+  }
+}

--- a/packages/sms-gate/src/index.ts
+++ b/packages/sms-gate/src/index.ts
@@ -1,0 +1,67 @@
+import type { BirrJSPlugin } from "@birrjs/core";
+
+import { SmsGateClient } from "./client";
+import {
+  formatMessage,
+  DEFAULT_PAYMENT_RECEIVED,
+  DEFAULT_PAYMENT_FAILED,
+  DEFAULT_SUBSCRIPTION_EXPIRED,
+  DEFAULT_SUBSCRIPTION_REMINDER,
+} from "./messages";
+import type { SmsGateConfig } from "./types";
+import { getPhone } from "./utils";
+
+export type { SmsGateConfig };
+export {
+  SmsGateClient,
+  SmsGateError,
+  SmsGateAuthError,
+  SmsGateDeviceError,
+  SmsGateQueueError,
+  SmsGateValidationError,
+} from "./client";
+
+export function smsGate(config: SmsGateConfig): BirrJSPlugin {
+  const client = new SmsGateClient(config);
+
+  return {
+    id: "sms-gate",
+    onEvent: {
+      "subscription.activated": async (payload, ctx) => {
+        const phone = await getPhone(payload.customerId, ctx);
+        if (!phone) return;
+        const message = formatMessage(config.messages?.paymentReceived, DEFAULT_PAYMENT_RECEIVED, {
+          planName: payload.planName,
+        });
+        await client.send(phone, message);
+      },
+      "subscription.cancelled": async (payload, ctx) => {
+        const phone = await getPhone(payload.customerId, ctx);
+        if (!phone) return;
+        const message = formatMessage(config.messages?.paymentFailed, DEFAULT_PAYMENT_FAILED, {
+          planName: payload.planName,
+        });
+        await client.send(phone, message);
+      },
+      "subscription.expired": async (payload, ctx) => {
+        const phone = await getPhone(payload.customerId, ctx);
+        if (!phone) return;
+        const message = formatMessage(
+          config.messages?.subscriptionExpired,
+          DEFAULT_SUBSCRIPTION_EXPIRED,
+          { planName: payload.planName },
+        );
+        await client.send(phone, message);
+      },
+      "subscription.reminder": async (payload, _ctx) => {
+        if (!payload.customerPhone) return;
+        const message = formatMessage(
+          config.messages?.subscriptionReminder,
+          DEFAULT_SUBSCRIPTION_REMINDER,
+          { daysUntil: String(payload.daysUntilExpiry), planName: payload.planName },
+        );
+        await client.send(payload.customerPhone, message);
+      },
+    },
+  };
+}

--- a/packages/sms-gate/src/messages.ts
+++ b/packages/sms-gate/src/messages.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_PAYMENT_RECEIVED = "Your payment has been received. Thank you!";
+export const DEFAULT_PAYMENT_FAILED = "Your payment failed. Please update your payment method.";
+export const DEFAULT_SUBSCRIPTION_EXPIRED =
+  "Your subscription has expired. Renew now to continue access.";
+export const DEFAULT_SUBSCRIPTION_REMINDER =
+  "Reminder: your subscription expires in {daysUntil} days. Renew now!";
+
+export function formatMessage(
+  template: string | undefined,
+  fallback: string,
+  vars: Record<string, string>,
+): string {
+  const tpl = template ?? fallback;
+  return tpl.replace(/\{(\w+)\}/g, (_, key) => vars[key] ?? `{${key}}`);
+}

--- a/packages/sms-gate/src/types.ts
+++ b/packages/sms-gate/src/types.ts
@@ -1,0 +1,13 @@
+export interface SmsGateConfig {
+  username: string;
+  password: string;
+  deviceId?: string;
+  baseUrl?: string;
+  simNumber?: number;
+  messages?: {
+    paymentReceived?: string;
+    paymentFailed?: string;
+    subscriptionExpired?: string;
+    subscriptionReminder?: string;
+  };
+}

--- a/packages/sms-gate/src/utils.ts
+++ b/packages/sms-gate/src/utils.ts
@@ -1,0 +1,9 @@
+import type { BirrJSContext } from "@birrjs/core";
+
+export async function getPhone(
+  customerId: string,
+  ctx: BirrJSContext,
+): Promise<string | undefined> {
+  const customer = await ctx.queries.getCustomer(customerId);
+  return customer?.phone ?? undefined;
+}

--- a/packages/sms-gate/tsconfig.build.json
+++ b/packages/sms-gate/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/__tests__/**"]
+}

--- a/packages/sms-gate/tsconfig.json
+++ b/packages/sms-gate/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/sms-gate/tsdown.config.ts
+++ b/packages/sms-gate/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsdown";
+
+import { createPackageTsdownConfig } from "../../tsdown.base.ts";
+
+export default defineConfig(
+  createPackageTsdownConfig({
+    entry: {
+      index: "src/index.ts",
+    },
+  }),
+);

--- a/packages/sms-gate/vitest.config.ts
+++ b/packages/sms-gate/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,9 @@ importers:
       '@birrjs/core':
         specifier: workspace:*
         version: link:../packages/core
+      '@birrjs/sms-gate':
+        specifier: workspace:*
+        version: link:../packages/sms-gate
       '@types/pg':
         specifier: ^8.18.0
         version: 8.20.0
@@ -626,6 +629,22 @@ importers:
         version: 4.1.6(@types/node@25.6.0)(@vitest/ui@4.1.6)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.2))(vite@8.0.13(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/sms-afromessage:
+    dependencies:
+      '@birrjs/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      tsdown:
+        specifier: ^0.21.1
+        version: 0.21.7(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.2)
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.6.0)(@vitest/ui@4.1.6)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.2))(vite@8.0.13(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/sms-gate:
     dependencies:
       '@birrjs/core':
         specifier: workspace:*
@@ -8023,6 +8042,7 @@ snapshots:
     optionalDependencies:
       msw: 2.14.6(@types/node@20.19.41)(typescript@6.0.3)
       vite: 8.0.13(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+    optional: true
 
   '@vitest/mocker@4.1.6(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.2))(vite@8.0.13(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -8069,7 +8089,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@20.19.41)(@vitest/ui@4.1.6)(msw@2.14.6(@types/node@20.19.41)(typescript@6.0.3))(vite@8.0.13(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.6(@types/node@25.6.0)(@vitest/ui@4.1.6)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.2))(vite@8.0.13(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.6':
     dependencies:
@@ -11385,6 +11405,7 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.21.0
       yaml: 2.8.3
+    optional: true
 
   vite@8.0.13(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -11418,7 +11439,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.2.4
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.13(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -11428,6 +11449,7 @@ snapshots:
       '@vitest/ui': 4.1.6(vitest@4.1.6)
     transitivePeerDependencies:
       - msw
+    optional: true
 
   vitest@4.1.6(@types/node@25.6.0)(@vitest/ui@4.1.6)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.2))(vite@8.0.13(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -11446,7 +11468,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.2.4
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.13(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -11474,7 +11496,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.2.4
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.13(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)


### PR DESCRIPTION
not having a license shouldn't stop you from sending SMS 😁

> SMS-Gate is an open-source Android app that turns any phone with a SIM card into an SMS gateway. You install it on a device, connect it to their free cloud server (or self-host), and hit a REST API to send SMS through that phone's cellular connection. No carrier API subscriptions, no regulatory paperwork — just an Android phone and a SIM.

Adds a new notification plugin that sends SMS via sms-gate.app when
subscription events fire (activated, cancelled, expired, reminder).

Uses username/password auth with automatic JWT token refresh — no
manual token management needed. Works with the cloud API out of the
box, also supports self-hosted servers via baseUrl config.

Handles the full event surface:
- subscription.activated
- subscription.cancelled  
- subscription.expired
- subscription.reminder

Has typed errors for the common failure modes (bad credentials, queue
limits, device permission issues, modem errors) so callers can handle
them properly instead of guessing from HTTP status codes.

Includes smoke tests in e2e/smoke/ that can run against a real
sms-gate.app account.